### PR TITLE
[bugfix] Multiple eval datasets have bug in metrics calculation

### DIFF
--- a/stable_ssl/base.py
+++ b/stable_ssl/base.py
@@ -374,19 +374,19 @@ class BaseModel(torch.nn.Module):
             logging.info("No val_loader hence skipping eval epoch.")
             return
 
+        # set-up model in eval mode + reset metrics
+        self.before_eval_epoch()
+        # we do not ensure that the model is still in eval mode to not
+        # override any user desired behavior
+        if self.training:
+            logging.warning(
+                "Starting eval epoch but model is not in "
+                "eval mode after call to before_eval_epoch()."
+            )
+
         for name_loader, loader in self.dataloaders.items():
             if name_loader == self.config.data.train_on:
                 continue
-            # set-up model in eval mode + reset metrics
-            self.before_eval_epoch()
-
-            # we do not ensure that the model is still in eval mode to not
-            # override any user desired behavior
-            if self.training:
-                logging.warning(
-                    "Starting eval epoch but model is not in "
-                    "eval mode after call to before_eval_epoch()."
-                )
 
             try:
                 max_steps = len(loader)
@@ -419,8 +419,8 @@ class BaseModel(torch.nn.Module):
             # be sure to clean up to avoid silent bugs
             self.data = None
 
-            # call any user specified post-epoch function
-            self.after_eval_epoch()
+        # call any user specified post-epoch function
+        self.after_eval_epoch()
 
     def train_step(self):
         self.optimizer.zero_grad(set_to_none=True)

--- a/stable_ssl/data/base.py
+++ b/stable_ssl/data/base.py
@@ -122,7 +122,7 @@ class DatasetConfig:
         # )
         if self.num_workers == -1:
             if os.environ.get("SLURM_JOB_ID"):
-                num_workers = os.environ.get("SLURM_JOB_CPUS_PER_NODE", 1)
+                num_workers = int(os.environ.get("SLURM_JOB_CPUS_PER_NODE", 1))
             else:
                 num_workers = os.cpu_count()
             logging.info(


### PR DESCRIPTION
```
/oscar/home/vsharm44/projects/ssl-perturbation-augmentation/.venv/lib64/python3.9/site-packages/torchmetrics/utilities/prints.py:43: UserWarning: The ``compute`` method of metric MulticlassAccuracy was called before the ``update`` method which may lead to errors, as metric states have not yet been updated.
  warnings.warn(*args, **kwargs)  # noqa: B028
```