### PR TITLE
[BugFix] Don't append name of the dataset to path by default.

### DIFF
--- a/stable_ssl/data/base.py
+++ b/stable_ssl/data/base.py
@@ -86,7 +86,7 @@ class DatasetConfig:
             )
         else:
             self.path = os.path.expanduser(self.path)
-            return os.path.join(self.path, self.name)
+            return self.path
 
     def get_dataset(self):
         """Load a dataset with torchvision.datasets.


### PR DESCRIPTION
User needs to pass the full path to the dataset and in case of ImageFolder the full path to the split. Prevent unexpected user side behavior by automatic path appending etc.