### PR TITLE
[Minor] make loss optional in the BaseTrainer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,7 +123,7 @@ Examples of Methods
 +----------------+--------------------------------------------+---------------------------------+
 
 
-.. _exsimclr: _github_url/blob/main/examples/simclr_cifar10_full.yaml
+.. _exsimclr: https://github.com/huguesva/stable-SSL/tree/main/examples/config_examples/simclr_cifar10_full.yaml
 
 .. _ntxent: https://rbalestr-lab.github.io/stable-SSL.github.io/dev/gen_modules/stable_ssl.losses.NTXEntLoss.html#stable_ssl.losses.NTXEntLoss
 .. _barlow: https://rbalestr-lab.github.io/stable-SSL.github.io/dev/gen_modules/stable_ssl.losses.BarlowTwinsLoss.html#stable_ssl.losses.BarlowTwinsLoss

--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,8 @@ We achieve that by taking the best--and only the best--from the most eponymous A
 ``stable-SSL`` implements all the basic boilerplate code, including data loading, logging, checkpointing and optimization. It offers users full flexibility to customize each part of the pipeline through a configuration file, enabling easy selection of network architectures, loss functions, evaluation metrics, data augmentations and more.
 These components can be sourced from ``stable-SSL`` itself, popular libraries like ``PyTorch``, or custom modules created by the user.
 
+While the organization is similar to that of ``PyTorch Lightning``, the goal of ``stable-SSL`` is to significantly reduce codebase complexity without sacrificing performance. Think of ``PyTorch Lightning`` as industry-driven (abstracting everything away), whereas ``stable-SSL`` is academia-driven (providing users with complete visibility into every aspect).
+
 
 Why stable-SSL?
 ---------------
@@ -27,9 +29,9 @@ Why stable-SSL?
 
 A quick search of ``AI libraries`` or ``Self Supervised Learning libraries`` will return hundreds of results. 99% will be independent project-centric libraries that can't be reused for general purpose AI research. The other 1% includes:
 
-- Framework libraries such as PytorchLightning that focus on production needs.
-- SSL libraries such as VISSL, FFCV-SSL, LightlySSL that are too rigid, often discontinued or not maintained, or commercial.
-- Standalone libraries such as Wandb, submitit, Hydra that do not offer enough boilerplate for AI research.
+- Framework libraries such as ``PytorchLightning`` that focus on production needs.
+- SSL libraries such as ``VISSL``, ``FFCV-SSL``, ``LightlySSL`` that are discontinued, not maintained or too rigid.
+- Standalone libraries such as ``Wandb``, ``submitit``, ``Hydra`` that do not offer enough boilerplate for AI research.
 
 Hence our goal is to fill that void.
 
@@ -55,35 +57,21 @@ Or you can also run:
 Minimal Documentation
 ---------------------
 
-Library Design
-~~~~~~~~~~~~~~
-
-.. _design:
-
 ``stable-SSL`` provides all the boilerplate to quickly get started with AI research, focusing on Self-Supervised Learning (SSL), albeit other applications can certainly build upon ``stable-SSL``.
-At its core, ``stable-SSL`` provides a `BaseTrainer <https://rbalestr-lab.github.io/stable-SSL.github.io/dev/gen_modules/stable_ssl.BaseTrainer.html#stable_ssl.BaseTrainer>`_ class that provides all the essential methods required to train and evaluate your model effectively. This class is intended to be subclassed for specific training needs (see these `trainers <https://rbalestr-lab.github.io/stable-SSL.github.io/dev/trainers.html>`_ as examples). For detailed instructions on configuring the trainers' input parameters, refer to the `User Guide <https://rbalestr-lab.github.io/stable-SSL.github.io/dev/user_guide.html>`_.
+At its core, ``stable-SSL`` provides a `BaseTrainer <https://rbalestr-lab.github.io/stable-SSL.github.io/dev/gen_modules/stable_ssl.BaseTrainer.html#stable_ssl.BaseTrainer>`_ class that provides all the essential methods required to train and evaluate your model effectively. This class is intended to be subclassed for specific training needs (see these `trainers <https://rbalestr-lab.github.io/stable-SSL.github.io/dev/trainers.html>`_ as examples).
 
-While the organization is similar to that of ``PyTorch Lightning``, the goal of ``stable-SSL`` is to significantly reduce codebase complexity without sacrificing performance. Think of ``PyTorch Lightning`` as industry-driven (abstracting everything away), whereas ``stable-SSL`` is academia-driven (providing users with complete visibility into every aspect).
-
-
-How to launch runs
-~~~~~~~~~~~~~~~~~~
-
-.. _launch:
-
-When using ``stable-SSL``, we recommend relying on configuration files to specify the parameters, typically using ``Hydra`` (see `Hydra documentation <https://hydra.cc/>`_).
-
+``stable-SSL`` relies on ``Hydra`` (see `Hydra documentation <https://hydra.cc/>`_) to manage the configuration parameters.
 The parameters are organized into the following groups (more details in the `User Guide <https://rbalestr-lab.github.io/stable-SSL.github.io/dev/user_guide.html>`_):
 
 * **data**: Defines the dataset, loading, and augmentation pipelines. Only the dataset called ``train`` is used for training. If there is no dataset named ``train``, the model runs in evaluation mode. `Example <https://rbalestr-lab.github.io/stable-SSL.github.io/dev/user_guide.html#data>`_.
 * **module**: Specifies the neural network modules, with a required ``backbone`` as the model's core. `Example <https://rbalestr-lab.github.io/stable-SSL.github.io/dev/user_guide.html#module>`_.
-* **loss**: Defines the model's loss function. `Example <https://rbalestr-lab.github.io/stable-SSL.github.io/dev/user_guide.html#loss>`_.
 * **optim**: Contains optimization parameters, including ``epochs``, ``max_steps`` (per epoch), and ``optimizer`` / ``scheduler`` settings. `Example <https://rbalestr-lab.github.io/stable-SSL.github.io/dev/user_guide.html#optim>`_.
 * **hardware**: Specifies the hardware used, including the number of GPUs, CPUs, etc. `Example <https://rbalestr-lab.github.io/stable-SSL.github.io/dev/user_guide.html#hardware>`_.
 * **logger**: Configures model performance monitoring. APIs like `WandB <https://wandb.ai/home>`_ are supported. `Example <https://rbalestr-lab.github.io/stable-SSL.github.io/dev/user_guide.html#logger>`_.
+* **loss** (optional): Defines a loss function that can then be used in the ``compute_loss`` method of the trainer. `Example <https://rbalestr-lab.github.io/stable-SSL.github.io/dev/user_guide.html#loss>`_.
 
 
-Then, create a Python script that will load the configuration and launch the run. Here is an example with Hydra:
+Then, create a Python script that will load the configuration and launch the run.
 
 .. code-block:: python
    :name: run.py
@@ -116,21 +104,21 @@ In this example, to launch the run using the configuration file ``default_config
 Examples of Methods
 ~~~~~~~~~~~~~~~~~~~
 
-+----------------+--------------------------------------------+------------------------------------------+---------------------------------+
-| **Method**     | **Trainer**                                | **Loss**                                 | **Example Config**              |
-+----------------+--------------------------------------------+------------------------------------------+---------------------------------+
-| Barlow Twins   | `JointEmbeddingTrainer <jointembed_>`_     | `BarlowTwinsLoss <barlow_>`_             |                                 |
-+----------------+--------------------------------------------+------------------------------------------+---------------------------------+
-| BYOL           | `SelfDistillationTrainer <selfdistill_>`_  | `NegativeCosineSimilarity <negcosine_>`_ |                                 |
-+----------------+--------------------------------------------+------------------------------------------+---------------------------------+
-| MoCo           | `SelfDistillationTrainer <selfdistill_>`_  | `NTXEntLoss <ntxent_>`_                  |                                 |
-+----------------+--------------------------------------------+------------------------------------------+---------------------------------+
-| SimCLR         | `JointEmbeddingTrainer <jointembed_>`_     | `NTXEntLoss <ntxent_>`_                  | `link <exsimclr_>`_             |
-+----------------+--------------------------------------------+------------------------------------------+---------------------------------+
-| SimSiam        | `SelfDistillationTrainer <selfdistill_>`_  | `NegativeCosineSimilarity <negcosine_>`_ |                                 |
-+----------------+--------------------------------------------+------------------------------------------+---------------------------------+
-| VICReg         | `JointEmbeddingTrainer <jointembed_>`_     | `VICRegLoss <vicreg_>`_                  |                                 |
-+----------------+--------------------------------------------+------------------------------------------+---------------------------------+
++----------------+--------------------------------------------+---------------------------------+
+| **Method**     | **Trainer**                                | **Example Config**              |
++----------------+--------------------------------------------+---------------------------------+
+| Barlow Twins   | `JointEmbeddingTrainer <jointembed_>`_     |                                 |
++----------------+--------------------------------------------+---------------------------------+
+| BYOL           | `SelfDistillationTrainer <selfdistill_>`_  |                                 |
++----------------+--------------------------------------------+---------------------------------+
+| MoCo           | `SelfDistillationTrainer <selfdistill_>`_  |                                 |
++----------------+--------------------------------------------+---------------------------------+
+| SimCLR         | `JointEmbeddingTrainer <jointembed_>`_     | `link <exsimclr_>`_             |
++----------------+--------------------------------------------+---------------------------------+
+| SimSiam        | `SelfDistillationTrainer <selfdistill_>`_  |                                 |
++----------------+--------------------------------------------+---------------------------------+
+| VICReg         | `JointEmbeddingTrainer <jointembed_>`_     |                                 |
++----------------+--------------------------------------------+---------------------------------+
 
 
 .. _exsimclr: _github_url/blob/main/examples/simclr_cifar10_full.yaml

--- a/README.rst
+++ b/README.rst
@@ -12,14 +12,14 @@
 The Self-Supervised Learning Library by Researchers for Researchers
 ===================================================================
 
-*Have a research idea? With stable-SSL, you can go from concept to execution in under 10 minutes. Start from scratch and quickly set up your pipeline, all while being able to generate high-quality figures and tables from your results. That's the goal of stable-SSL.*
+*Got a research idea? With stable-SSL, you can go from concept to execution in under 10 minutes. Start from scratch and quickly set up your pipeline, all while being able to generate high-quality figures and tables from your results. That's the goal of stable-SSL.*
 
 We achieve that by taking the best--and only the best--from the most eponymous AI libraries: ``PytorchLightning``, ``VISSL``, ``WandB``, ``Hydra``, ``Submitit``.
 
-``stable-SSL`` implements all the basic boilerplate code, including data loading, logging, checkpointing and optimization. It offers users full flexibility to customize each part of the pipeline through a configuration file, enabling easy selection of network architectures, loss functions, evaluation metrics, data augmentations and more.
+``stable-SSL`` implements all the basic boilerplate code, including job submission, data loading, optimization, evaluation, logging, monitoring, checkpointing, and requeuing. It offers users full flexibility to customize each part of the pipeline through a configuration file, enabling easy selection of network architectures, loss functions, evaluation metrics, data augmentations, and more.
 These components can be sourced from ``stable-SSL`` itself, popular libraries like ``PyTorch``, or custom modules created by the user.
 
-While the organization is similar to that of ``PyTorch Lightning``, the goal of ``stable-SSL`` is to significantly reduce codebase complexity without sacrificing performance. Think of ``PyTorch Lightning`` as industry-driven (abstracting everything away), whereas ``stable-SSL`` is academia-driven (providing users with complete visibility into every aspect).
+While the organization is similar to that of ``PyTorch Lightning``, the goal of ``stable-SSL`` is to significantly reduce codebase complexity without sacrificing performance. Think of ``PyTorch Lightning`` as industry-driven (abstracting everything away), whereas ``stable-SSL`` is academia-driven (offering complete visibility into all important aspects of the pipeline.).
 
 
 Why stable-SSL?
@@ -111,6 +111,8 @@ Examples of Methods
 +----------------+--------------------------------------------+---------------------------------+
 | BYOL           | `SelfDistillationTrainer <selfdistill_>`_  |                                 |
 +----------------+--------------------------------------------+---------------------------------+
+| DINO           | `DINOTrainer <dinotrainer_>`_              |                                 |
++----------------+--------------------------------------------+---------------------------------+
 | MoCo           | `SelfDistillationTrainer <selfdistill_>`_  |                                 |
 +----------------+--------------------------------------------+---------------------------------+
 | SimCLR         | `JointEmbeddingTrainer <jointembed_>`_     | `link <exsimclr_>`_             |
@@ -129,7 +131,8 @@ Examples of Methods
 .. _vicreg: https://rbalestr-lab.github.io/stable-SSL.github.io/dev/gen_modules/stable_ssl.losses.VICRegLoss.html
 
 .. _jointembed: https://rbalestr-lab.github.io/stable-SSL.github.io/dev/gen_modules/stable_ssl.trainers.JointEmbeddingTrainer.html
-.. _selfdistill: https://rbalestr-lab.github.io/stable-SSL.github.io/dev/gen_modules/stable_ssl.trainers.SelfDistillationTrainer.html#stable_ssl.trainers.SelfDistillationTrainer
+.. _selfdistill: https://rbalestr-lab.github.io/stable-SSL.github.io/dev/gen_modules/stable_ssl.trainers.SelfDistillationTrainer.html
+.. _dinotrainer: https://rbalestr-lab.github.io/stable-SSL.github.io/dev/gen_modules/stable_ssl.trainers.DINOTrainer.html
 
 
 

--- a/benchmarks/config/experiment/dino_cifar10.yaml
+++ b/benchmarks/config/experiment/dino_cifar10.yaml
@@ -4,10 +4,10 @@ trainer:
   # ===== Base Trainer =====
   _target_: stable_ssl.trainers.DINOTrainer
 
-  # ===== loss Parameters =====
-  loss:
-    _target_: stable_ssl.NTXEntLoss
-    temperature: 0.5
+  # # ===== loss Parameters =====
+  # loss:
+  #   _target_: stable_ssl.NTXEntLoss
+  #   temperature: 0.5
 
   # ===== Data Parameters =====
   data:

--- a/benchmarks/config/experiment/dino_cifar10.yaml
+++ b/benchmarks/config/experiment/dino_cifar10.yaml
@@ -4,11 +4,6 @@ trainer:
   # ===== Base Trainer =====
   _target_: stable_ssl.trainers.DINOTrainer
 
-  # # ===== loss Parameters =====
-  # loss:
-  #   _target_: stable_ssl.NTXEntLoss
-  #   temperature: 0.5
-
   # ===== Data Parameters =====
   data:
     _num_classes: 10

--- a/examples/config_examples/simclr_cifar10_full.yaml
+++ b/examples/config_examples/simclr_cifar10_full.yaml
@@ -17,11 +17,11 @@ hydra:
 
 trainer:
   # ===== Base Trainer =====
-  _target_: stable_ssl.JointEmbeddingTrainer
+  _target_: stable_ssl.trainers.JointEmbeddingTrainer
 
   # ===== loss Parameters =====
   loss:
-    _target_: stable_ssl.NTXEntLoss
+    _target_: stable_ssl.losses.NTXEntLoss
     temperature: 0.5
 
   # ===== Data Parameters =====
@@ -94,32 +94,19 @@ trainer:
   module:
     backbone:
       _target_: stable_ssl.modules.load_backbone
-      name: resnet18
+      name: resnet50
       low_resolution: True
       num_classes: null
     projector:
-      _target_: torch.nn.Sequential
-      _args_:
-        - _target_: torch.nn.Linear
-          in_features: 512
-          out_features: 2048
-          bias: False
-        - _target_: torch.nn.BatchNorm1d
-          num_features: ${trainer.module.projector._args_.0.out_features}
-        - _target_: torch.nn.ReLU
-        - _target_: torch.nn.Linear
-          in_features: ${trainer.module.projector._args_.0.out_features}
-          out_features: 128
-          bias: False
-        - _target_: torch.nn.BatchNorm1d
-          num_features: ${trainer.module.projector._args_.3.out_features}
+      _target_: stable_ssl.modules.MLP
+      sizes: [2048, 2048, 128]
     projector_classifier:
       _target_: torch.nn.Linear
       in_features: 128
       out_features: ${trainer.data._num_classes}
     backbone_classifier:
       _target_: torch.nn.Linear
-      in_features: 512
+      in_features: 2048
       out_features: ${trainer.data._num_classes}
 
   # ===== Optim Parameters =====
@@ -144,9 +131,9 @@ trainer:
 
   # ===== Logging Parameters =====
   logger:
-    level: 20
     checkpoint_frequency: 10
-    log_every_step: 1
+    log_every_step: 100
+    eval_every_epoch: 10
     metric:
       test:
         acc1:

--- a/stable_ssl/base.py
+++ b/stable_ssl/base.py
@@ -207,21 +207,12 @@ class BaseTrainer(torch.nn.Module):
     def predict(self):
         """Generate model predictions for evaluation purposes.
 
-        This method should produce the model's predictions based on the current
-        input batch. It is primarily used to evaluate the performance of both supervised
-        and self-supervised learning (SSL) models.
+        Supervised and Self-Supervised models are typically evaluated using
+        predictions over discrete labels. This method should return the output
+        of this classification used for evaluation.
 
-        For **Supervised Learning**:
-            Predictions typically involve classifying inputs into discrete labels
-            using the model's output logits or probabilities.
-
-        For **Self-Supervised Learning (SSL)**:
-            Evaluation requires adding a classifier head on top of the backbone network.
-            This transforms the SSL model into a supervised model,
-            enabling the computation of metrics based on discrete labels.
-
-        Implementations of this method should ensure that the returned predictions
-        are compatible with the evaluation metrics used within the training framework.
+        In SSL, this typically involves using a classifier head on top of the backbone,
+        thus turning the SSL model into a supervised model for evaluation.
 
         **See Also**:
             :mod:`stable_ssl.trainers` for concrete examples of implementations.
@@ -232,13 +223,12 @@ class BaseTrainer(torch.nn.Module):
     def compute_loss(self):
         """Calculate the global loss to be minimized during training.
 
-        This method is responsible for computing the total loss that the
-        model aims to minimize. Implementations can utilize the ``loss`` function
-        provided during the trainer's initialization to calculate loss based on the
-        current input batch.
+        Compute the total loss that the model aims to minimize.
+        Implementations can utilize the ``loss`` function provided during the
+        trainer's initialization to calculate loss based on the current batch.
 
         Note that it can return a list or dictionary of losses. The various losses
-        are then summed to compute the final loss but logged independently.
+        are logged independently and summed to compute the final loss.
 
         **See Also**:
             :mod:`stable_ssl.trainers` for concrete examples of implementations.

--- a/stable_ssl/base.py
+++ b/stable_ssl/base.py
@@ -205,12 +205,44 @@ class BaseTrainer(torch.nn.Module):
 
     @abstractmethod
     def predict(self):
-        """Prediction of the model used for evaluation."""
+        """Generate model predictions for evaluation purposes.
+
+        This method should produce the model's predictions based on the current
+        input batch. It is primarily used to evaluate the performance of both supervised
+        and self-supervised learning (SSL) models.
+
+        For **Supervised Learning**:
+            Predictions typically involve classifying inputs into discrete labels
+            using the model's output logits or probabilities.
+
+        For **Self-Supervised Learning (SSL)**:
+            Evaluation requires adding a classifier head on top of the backbone network.
+            This transforms the SSL model into a supervised model,
+            enabling the computation of metrics based on discrete labels.
+
+        Implementations of this method should ensure that the returned predictions
+        are compatible with the evaluation metrics used within the training framework.
+
+        **See Also**:
+            :mod:`stable_ssl.trainers` for concrete examples of implementations.
+        """
         pass
 
     @abstractmethod
     def compute_loss(self):
-        """Compute the global loss to be minimized."""
+        """Calculate the global loss to be minimized during training.
+
+        This method is responsible for computing the total loss that the
+        model aims to minimize. Implementations can utilize the ``loss`` function
+        provided during the trainer's initialization to calculate loss based on the
+        current input batch.
+
+        Note that it can return a list or dictionary of losses. The various losses
+        are then summed to compute the final loss but logged independently.
+
+        **See Also**:
+            :mod:`stable_ssl.trainers` for concrete examples of implementations.
+        """
         pass
 
     def get_logs(self, keys=None):
@@ -302,10 +334,10 @@ class BaseTrainer(torch.nn.Module):
         model = type(self)(
             self._data,
             self._module,
-            self._loss,
             self._hardware,
             self._optim,
             self._logger,
+            self._loss,
             **self._kwargs,
         )
         logging.info("Cleaning up the current task before submitting a new one.")

--- a/stable_ssl/base.py
+++ b/stable_ssl/base.py
@@ -66,7 +66,8 @@ class BaseTrainer(torch.nn.Module):
 
     This class is intended to be subclassed for specific training methods
     (see examples for more details). For each subclass, the following methods must
-    be implemented: ``forward``, ``predict``, and ``compute_loss``.
+    be implemented: ``forward``, ``predict`` (used for supervised evaluation) and
+    ``compute_loss`` (used for training).
 
     Execution flow when calling `launch`:
             - `self.before_fit` (nothing by default)

--- a/stable_ssl/base.py
+++ b/stable_ssl/base.py
@@ -181,7 +181,6 @@ class BaseTrainer(torch.nn.Module):
         ----------
         BreakAllEpochs
             Raised if the training is interrupted by the user.
-
         """
         if "train" not in self.data:
             self._evaluate()

--- a/stable_ssl/trainers.py
+++ b/stable_ssl/trainers.py
@@ -35,6 +35,13 @@ class SupervisedTrainer(BaseTrainer):
 
     def compute_loss(self):
         """Compute the loss of the model using the `loss` provided in the config."""
+        if self.loss is None:
+            log_and_raise(
+                ValueError,
+                f"When using the trainer {self.__class__.__name__}, "
+                "one needs to either provide a loss function in the config "
+                "or implement a custom `compute_loss` method.",
+            )
         loss = self.loss(self.predict(), self.batch[1])
         return {"loss": loss}
 
@@ -82,6 +89,14 @@ class JointEmbeddingTrainer(BaseTrainer):
 
     def compute_loss(self):
         """Compute final loss as sum of SSL loss and classifier losses."""
+        if self.loss is None:
+            log_and_raise(
+                ValueError,
+                f"When using the trainer {self.__class__.__name__}, "
+                "one needs to either provide a loss function in the config "
+                "or implement a custom `compute_loss` method.",
+            )
+
         views, labels = self.format_views_labels()
         embeddings = [self.module["backbone"](view) for view in views]
         self.latest_forward = embeddings
@@ -128,6 +143,14 @@ class SelfDistillationTrainer(JointEmbeddingTrainer):
 
     def compute_loss(self):
         """Compute final loss as sum of SSL loss and classifier losses."""
+        if self.loss is None:
+            log_and_raise(
+                ValueError,
+                f"When using the trainer {self.__class__.__name__}, "
+                "one needs to either provide a loss function in the config "
+                "or implement a custom `compute_loss` method.",
+            )
+
         views, labels = self.format_views_labels()
 
         embeddings_student = [


### PR DESCRIPTION
Since the loss can be handled completely by the ``compute_loss`` method, there is sometimes no need for a ``loss`` module to be passed as input to the BaseTrainer (see DINOTrainer for instance).