### PR TITLE
[Bugfix] RepeatedSampler Replicas 

### DIFF
--- a/stable_ssl/data/sampler.py
+++ b/stable_ssl/data/sampler.py
@@ -60,7 +60,7 @@ class RepeatedRandomSampler(torch.utils.data.DistributedSampler):
                 (self._data_source_len - self.num_replicas) / self.num_replicas  # type: ignore[arg-type]
             )
         else:
-            self.num_samples = self._data_source_len
+            self.num_samples = self._data_source_len // self.num_replicas  # type: ignore[arg-type]
 
         if not isinstance(self.replacement, bool):
             raise TypeError(
@@ -75,18 +75,9 @@ class RepeatedRandomSampler(torch.utils.data.DistributedSampler):
     #     return (len(self.data_source) * self.n_views) // self.num_replicas
 
     def __iter__(self) -> Iterator[int]:
-        """Iterate over the indices of the dataset.
-
-        Note: need to append the worker_id to the seed to ensure that each worker
-        gets a different random sequence. worker_init_fn is called only at the beginning
-
-        https://pytorch-lightning.readthedocs.io/en/1.7.7/api/pytorch_lightning.utilities.seed.html#pytorch_lightning.utilities.seed.seed_everything
-        """
         n = self._data_source_len
         g = torch.Generator()
-        worker_info = torch.utils.data.get_worker_info()
-        worker_id = worker_info.id if worker_info else 0
-        g.manual_seed(self.seed + self.epoch + worker_id)
+        g.manual_seed(self.seed + self.epoch)
 
         if self.replacement:
             raise NotImplementedError()

--- a/stable_ssl/tests/unit/test_datasets.py
+++ b/stable_ssl/tests/unit/test_datasets.py
@@ -174,7 +174,7 @@ class TestDatasetUnit:
         assert renamed_data["toto"] == "image_data"
         assert renamed_data["label"] == 1
 
-    def test_repated_sampler_replicas(self):
+    def test_repeated_sampler_replicas(self):
         import stable_ssl as ssl
 
         results = {}

--- a/stable_ssl/tests/unit/test_datasets.py
+++ b/stable_ssl/tests/unit/test_datasets.py
@@ -173,3 +173,27 @@ class TestDatasetUnit:
         assert "image" not in renamed_data
         assert renamed_data["toto"] == "image_data"
         assert renamed_data["label"] == 1
+
+    def test_repated_sampler_replicas(self):
+        import stable_ssl as ssl
+
+        results = {}
+        num_replicas = 2
+        fake_data_source_len = 10
+
+        for rank in range(num_replicas):
+            with (
+                patch("torch.distributed.is_available", return_value=True),
+                patch("torch.distributed.is_initialized", return_value=True),
+                patch("torch.distributed.get_world_size", return_value=num_replicas),
+                patch("torch.distributed.get_rank", return_value=rank),
+            ):
+                sampler = ssl.data.RepeatedRandomSampler(
+                    data_source_or_len=fake_data_source_len, n_views=1, seed=42
+                )
+
+                epoch_len = len(list(iter(sampler)))
+                results[rank] = epoch_len
+
+        target_epoch_len = fake_data_source_len // num_replicas
+        assert all(results[rank] == target_epoch_len for rank in range(num_replicas))


### PR DESCRIPTION
## Description

<!--- What types of changes does your code introduce? -->
Fixed bug occurring when the data source length is divisible by the number of replicas.

The number of samples should be divided by the number of replicas to avoid empty data splits on some replicas.

Added unit test.

<!--- Please link to an existing issue here if one exists. -->


## Checklist

<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**Contributing**](https://rbalestr-lab.github.io/stable-SSL.github.io/dev/contributing.html#) document.
- [ ] The documentation is up-to-date with the changes I made (check build artifacts).
- [ ] All tests passed, and additional code has been **covered with new tests**.
- [ ] I have added the PR to the [**RELEASES.rst**](../RELEASES.rst) file.
