### PR TITLE
[BugFix] minari step dataset bounds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ dependencies = [
     "tabulate",
     "matplotlib",
     "requests-cache[all]",
-    "richuru"
+    "richuru",
+    "minari[hdf5]>=0.5.3",
 ]
 
 dynamic = ["version"]

--- a/stable_ssl/data/utils.py
+++ b/stable_ssl/data/utils.py
@@ -316,8 +316,11 @@ class MinariStepsDataset(Dataset):
         super().__init__(transform)
         self.num_steps = num_steps
         self.dataset = dataset
-        self.bounds = self.dataset.episode_indices
+
+        episode_lengths = [len(dataset[idx]) for idx in dataset.episode_indices[:-1]]
+        self.bounds = np.cumsum([0] + episode_lengths)
         self.bounds -= np.arange(self.dataset.total_episodes) * (num_steps - 1)
+
         self._length = (
             self.dataset.total_steps - (num_steps - 1) * self.dataset.total_episodes
         )


### PR DESCRIPTION
## Description

<!--- What types of changes does your code introduce? -->

Correctly compute starting episode indexes for MinariStepsDataset utils.

<!--- Please link to an existing issue here if one exists. -->


## Checklist

<!-- - Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have read the [**Contributing**](https://rbalestr-lab.github.io/stable-SSL.github.io/dev/contributing.html#) document.
- [ ] The documentation is up-to-date with the changes I made (check build artifacts).
- [ ] All tests passed, and additional code has been **covered with new tests**.
- [ ] I have added the PR to the [**RELEASES.rst**](../RELEASES.rst) file.
